### PR TITLE
fix: reasonable fallback if shares cannot be listed

### DIFF
--- a/custom_components/proton_drive/config_flow.py
+++ b/custom_components/proton_drive/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers import instance_id, selector
+from proton.proton import Share
 from slugify import slugify
 
 from .api import (
@@ -24,7 +25,10 @@ from .helpers import create_credentials_from_data, serialize_credentials_to_data
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from proton.proton import Credentials, Share
+    from proton.proton import Credentials
+
+
+INTERNAL_DEFAULT_SHARE_ID = "why-dont-you-accept-empty-strings"
 
 
 def form_config_auth(*, email: str | None) -> vol.Schema:
@@ -74,9 +78,14 @@ def form_config_mfa() -> vol.Schema:
 
 
 def form_config_folders(
-    *, share_id: str | None, root_folder: str | None, shares: list[Share]
+    *, share_id: str | None, root_folder: str | None, shares: list[Share] | None
 ) -> vol.Schema:
     """Create a form schema for the folders config step."""
+    fshares = (
+        shares
+        if shares
+        else [Share(Name="My files", ShareID=INTERNAL_DEFAULT_SHARE_ID)]
+    )
     return vol.Schema(
         {
             vol.Required(CONF_SHARE_ID, default=share_id): selector.SelectSelector(
@@ -84,7 +93,7 @@ def form_config_folders(
                     mode=selector.SelectSelectorMode.DROPDOWN,
                     options=[
                         selector.SelectOptionDict(label=share.Name, value=share.ShareID)
-                        for share in shares
+                        for share in fshares
                     ],
                 ),
             ),
@@ -232,10 +241,11 @@ class ProtonDriveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except ProtonDriveAPIError as error:
                 errors["base"] = "unknown"
                 description_placeholders["error"] = str(error)
-        assert self._shares is not None
 
         if user_input is not None:
             self._share_id = user_input[CONF_SHARE_ID]
+            if self._share_id == INTERNAL_DEFAULT_SHARE_ID:
+                self._share_id = ""
             self._root_folder = user_input[CONF_ROOT_FOLDER]
 
             return await self.__finish()

--- a/custom_components/proton_drive/manifest.json
+++ b/custom_components/proton_drive/manifest.json
@@ -20,5 +20,5 @@
     "aiofiles>=24.1.0",
     "gopy-ha-proton-drive==0.0.4"
   ],
-  "version": "0.0.9"
+  "version": "0.0.12"
 }


### PR DESCRIPTION
Improves #32 

The `assert` was in a silly place, ending up messing the flow completely. Instead, we can get rid of it and just allow the user to select their main share (by passing an empty string to the conf). As the form system doesn't like dropdowns with empty values, we put a dummy value which is later transformed back into empty string.

While this doesn't fix the related issue, it at least improves the feedback by showing the actual error, but also allow the complete the flow, albeit with less options to choose from.