### PR TITLE
Fix upload failures, clean up logging, and handle orphaned metadata

### DIFF
--- a/custom_components/proton_drive/api.py
+++ b/custom_components/proton_drive/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ from homeassistant.components.backup.util import suggested_filename
 
 from .cli import (
     CLIError,
+    NameConflictError,
     ProtonCLI,
 )
 from .const import DOMAIN, LOGGER
@@ -274,33 +276,51 @@ class ProtonDriveClient:
                     ),
                 )
 
+            write_start = time.monotonic()
             async with aiofiles.open(archive_path, "wb") as f:
                 async for chunk in await open_stream():
                     await f.write(chunk)
                     on_progress(bytes_uploaded=await f.tell() // 2)
                 size = await f.tell()
+            LOGGER.debug(
+                "Wrote local archive %s (%d bytes) in %.1fs, starting upload",
+                archive_name,
+                size,
+                time.monotonic() - write_start,
+            )
 
+            async def _upload(local_path: Path, timeout_s: float) -> None:
+                try:
+                    await self.__cli.run(
+                        "filesystem",
+                        "upload",
+                        str(local_path),
+                        str(self.__backup_folder),
+                        timeout_s=timeout_s,
+                        retries=2,
+                    )
+                except NameConflictError:
+                    # A retry of our own timed-out-but-actually-completed attempt: our filenames
+                    # embed the backup_id, so a conflict on our own name means we already uploaded it.
+                    LOGGER.info(
+                        "Upload of %s already completed (name conflict on retry), treating as success",
+                        local_path.name,
+                    )
+
+            # TODO: upload progress feedback is missing
+            upload_start = time.monotonic()
+            meta_task = asyncio.create_task(_upload(meta_path, ProtonCLI.METADATA_TIMEOUT_S))
+            archive_task = asyncio.create_task(_upload(archive_path, ProtonCLI.TRANSFER_TIMEOUT_S))
             try:
-                # TODO: upload progress feedback is missing
-                await asyncio.gather(
-                    self.__cli.run(
-                        "filesystem",
-                        "upload",
-                        str(meta_path),
-                        str(self.__backup_folder),
-                        timeout_s=ProtonCLI.METADATA_TIMEOUT_S,
-                        retries=2,
-                    ),
-                    self.__cli.run(
-                        "filesystem",
-                        "upload",
-                        str(archive_path),
-                        str(self.__backup_folder),
-                        timeout_s=ProtonCLI.TRANSFER_TIMEOUT_S,
-                        retries=2,
-                    ),
-                )
+                await asyncio.gather(meta_task, archive_task)
             except CLIError:
+                # asyncio.gather() does NOT cancel a still-running sibling when one task raises on its
+                # own (only when gather() itself is cancelled) - without this, the other upload keeps
+                # running in the background against files we're about to delete below.
+                for task in (meta_task, archive_task):
+                    task.cancel()
+                await asyncio.gather(meta_task, archive_task, return_exceptions=True)
+
                 filenames = [Path(metadata_name), Path(archive_name)]
                 LOGGER.exception("Failed to upload backup: %s, deleting...", filenames)
 
@@ -316,6 +336,7 @@ class ProtonDriveClient:
                     LOGGER.exception("Failed to clean up orphaned files after upload failure")
                 raise
 
+            LOGGER.debug("Uploaded %s in %.1fs", archive_name, time.monotonic() - upload_start)
             on_progress(bytes_uploaded=size)
 
     async def delete_backup(self, backup_id: str) -> None:

--- a/custom_components/proton_drive/api.py
+++ b/custom_components/proton_drive/api.py
@@ -309,7 +309,7 @@ class ProtonDriveClient:
                     to_delete = [f for f in to_delete if await self.__cli.exists(f)]
                     await self.__cli.trash(*to_delete)
 
-                    if self.__can_delete_file(self.__backup_folder):
+                    if to_delete and self.__can_delete_file(self.__backup_folder):
                         trash = Path("/trash")
                         await self.__cli.run("filesystem", "delete", *[str(trash / Path(f).name) for f in to_delete])
                 except CLIError:
@@ -365,8 +365,24 @@ class ProtonDriveClient:
         """List Home Assistant backups."""
         files = await self.__cli.list_files(self.__backup_folder)
         metadata_suffix = self.__make_metadata_filename("", "")
+        archive_suffix = self.__make_backup_filename("", "")
         LOGGER.debug("Looking for metadata files with suffix: %s", metadata_suffix)
         metadata_files = [f for f in files if f.endswith(metadata_suffix)]
+        archive_files = [f for f in files if f.endswith(archive_suffix)]
+
+        file_set = set(files)
+        orphans = [f for f in metadata_files if not self.__has_matching_archive(f, files)]
+        orphans.extend(
+            f for f in archive_files if f.removesuffix(self.ARCHIVE_EXT) + self.METADATA_EXT not in file_set
+        )
+        if orphans:
+            LOGGER.warning("Trashing orphaned backup file(s) with no counterpart: %s", orphans)
+            try:
+                await self.__cli.trash(*map(self.__make_filepath, orphans))
+            except CLIError:
+                LOGGER.exception("Failed to trash orphaned backup files")
+
+        live_metadata_files = [f for f in metadata_files if f not in orphans]
 
         async def _fetch(filename: str) -> AgentBackup | None:
             try:
@@ -378,8 +394,14 @@ class ProtonDriveClient:
                 LOGGER.exception("Failed to read metadata %s", filename)
                 return None
 
-        results = await asyncio.gather(*[_fetch(f) for f in metadata_files])
+        results = await asyncio.gather(*[_fetch(f) for f in live_metadata_files])
         return [r for r in results if r is not None]
+
+    def __has_matching_archive(self, metadata_file: str, files: list[str]) -> bool:
+        # Chunked backups store their archive as numbered `NN.tar.part` files instead of a
+        # plain `.tar`, so we can't just check for one exact filename.
+        prefix = metadata_file.removesuffix(self.METADATA_EXT)
+        return any(f.startswith(prefix) and (f.endswith(self.ARCHIVE_EXT) or f.endswith(self.PART_EXT)) for f in files)
 
     @cached(cache=TTLCache(maxsize=1024, ttl=300))
     async def __read_metadata(self, metadata_file: str) -> Metadata | dict:

--- a/custom_components/proton_drive/api.py
+++ b/custom_components/proton_drive/api.py
@@ -393,9 +393,7 @@ class ProtonDriveClient:
 
         file_set = set(files)
         orphans = [f for f in metadata_files if not self.__has_matching_archive(f, files)]
-        orphans.extend(
-            f for f in archive_files if f.removesuffix(self.ARCHIVE_EXT) + self.METADATA_EXT not in file_set
-        )
+        orphans.extend(f for f in archive_files if f.removesuffix(self.ARCHIVE_EXT) + self.METADATA_EXT not in file_set)
         if orphans:
             LOGGER.warning("Trashing orphaned backup file(s) with no counterpart: %s", orphans)
             try:
@@ -422,7 +420,7 @@ class ProtonDriveClient:
         # Chunked backups store their archive as numbered `NN.tar.part` files instead of a
         # plain `.tar`, so we can't just check for one exact filename.
         prefix = metadata_file.removesuffix(self.METADATA_EXT)
-        return any(f.startswith(prefix) and (f.endswith(self.ARCHIVE_EXT) or f.endswith(self.PART_EXT)) for f in files)
+        return any(f.startswith(prefix) and f.endswith((self.ARCHIVE_EXT, self.PART_EXT)) for f in files)
 
     @cached(cache=TTLCache(maxsize=1024, ttl=300))
     async def __read_metadata(self, metadata_file: str) -> Metadata | dict:

--- a/custom_components/proton_drive/api.py
+++ b/custom_components/proton_drive/api.py
@@ -289,7 +289,7 @@ class ProtonDriveClient:
                         str(meta_path),
                         str(self.__backup_folder),
                         timeout_s=ProtonCLI.METADATA_TIMEOUT_S,
-                        retries=0,
+                        retries=2,
                     ),
                     self.__cli.run(
                         "filesystem",
@@ -297,7 +297,7 @@ class ProtonDriveClient:
                         str(archive_path),
                         str(self.__backup_folder),
                         timeout_s=ProtonCLI.TRANSFER_TIMEOUT_S,
-                        retries=0,
+                        retries=2,
                     ),
                 )
             except CLIError:

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -359,9 +359,7 @@ class ProtonCLI:
             async with asyncio.timeout(self.TERMINATE_GRACE_S):
                 await run.process.wait()
         except TimeoutError:
-            LOGGER.warning(
-                "[%s] Did not exit within %ss of SIGTERM, sending SIGKILL", run.id, self.TERMINATE_GRACE_S
-            )
+            LOGGER.warning("[%s] Did not exit within %ss of SIGTERM, sending SIGKILL", run.id, self.TERMINATE_GRACE_S)
             run.process.kill()
             # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
             await run.process.wait()

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -81,6 +81,10 @@ class APIUnavailableError(CLIError):
     """Exception to indicate a transient failure reaching the Proton API."""
 
 
+class CLIDatabaseLockedError(CLIError):
+    """Exception to indicate the CLI's local cache database was locked by a concurrent invocation."""
+
+
 def _transform_version(version: AwesomeVersion | None) -> str:
     """
     Map a manifest version into the SDK's `{semver}-{channel}[+{suffix}]` shape.
@@ -498,19 +502,39 @@ class ProtonCLI:
                     # otherwise it lingers and can crash later against files/state cleaned up by the caller.
                     self.__kill_and_reap(run)
                     raise
-                return self._process_run(run, stdout, stderr, is_json=is_json)
+                try:
+                    return self._process_run(run, stdout, stderr, is_json=is_json)
+                except CLIDatabaseLockedError:
+                    if attempt >= retries:
+                        raise
+                    attempt += 1
+                    delay = min(0.2 * 2 ** (attempt - 1), 2)
+                    LOGGER.warning(
+                        "[%s] CLI cache database locked by a concurrent call, retrying (%d/%d) in %.1fs",
+                        run.id,
+                        attempt,
+                        retries,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
 
     @classmethod
     def _process_run(cls, run: _CLIRun, stdout: bytes, stderr: bytes, *, is_json: bool = True) -> Any:
         if run.process.returncode != 0:
+            stdout_text = stdout.decode()
+            stderr_text = stderr.decode()
             LOGGER.warning(
                 "[%s] CLI Result %d: stdout=%s, stderr=%s",
                 run.id,
                 run.process.returncode,
-                stdout.decode(),
-                stderr.decode(),
+                stdout_text,
+                stderr_text,
             )
-            msg = stderr.decode()
+            if "SQLITE_BUSY" in stdout_text or "SQLITE_BUSY" in stderr_text:
+                msg = f"[{run.id}] CLI cache database is locked"
+                raise CLIDatabaseLockedError(msg)
+            msg = stderr_text
             if "Node not found" in msg:
                 raise NodeNotFoundError(msg)
             # FIXME: odd but that's only explanation I can think of

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -555,21 +555,31 @@ class ProtonCLI:
         if run.process.returncode != 0:
             stdout_text = stdout.decode()
             stderr_text = stderr.decode()
-            LOGGER.warning(
+
+            is_db_locked = "SQLITE_BUSY" in stdout_text or "SQLITE_BUSY" in stderr_text
+            is_name_conflict = "Name conflict on" in stdout_text and "already exists" in stdout_text
+            is_not_found = "Node not found" in stderr_text
+
+            # These are conditions the caller already expects and handles on its own (a retry, or
+            # treating it as non-fatal) - a WARNING for every occurrence is just noise; DEBUG still
+            # keeps the detail on hand if it's actually needed.
+            log = LOGGER.debug if (is_db_locked or is_name_conflict or is_not_found) else LOGGER.warning
+            log(
                 "[%s] CLI Result %d: stdout=%s, stderr=%s",
                 run.id,
                 run.process.returncode,
                 stdout_text,
                 stderr_text,
             )
-            if "SQLITE_BUSY" in stdout_text or "SQLITE_BUSY" in stderr_text:
+
+            if is_db_locked:
                 msg = f"[{run.id}] CLI cache database is locked"
                 raise CLIDatabaseLockedError(msg)
-            if "Name conflict on" in stdout_text and "already exists" in stdout_text:
+            if is_name_conflict:
                 msg = f"[{run.id}] Name conflict: {stdout_text}"
                 raise NameConflictError(msg)
             msg = stderr_text
-            if "Node not found" in msg:
+            if is_not_found:
                 raise NodeNotFoundError(msg)
             # FIXME: odd but that's only explanation I can think of
             if "You need to login first" in msg or "Root node not found" in msg:

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -108,7 +108,7 @@ class ProtonCLI:
 
     DEFAULT_TIMEOUT_S = 10
     METADATA_TIMEOUT_S = 60
-    TRANSFER_TIMEOUT_S = 10 * 60
+    TRANSFER_TIMEOUT_S = 60 * 60
 
     STALE_AUTH_THRESHOLD = timedelta(hours=24)
     STALE_AUTH_REQUIRED_SUCCESSES = 5
@@ -335,6 +335,13 @@ class ProtonCLI:
             raise CLIError(msg) from e
         return self._CLIRun(id=uid, process=proc)
 
+    def __kill_and_reap(self, run: _CLIRun) -> None:
+        run.process.kill()
+        # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
+        reap_task = asyncio.create_task(run.process.wait())
+        self.__reap_tasks.add(reap_task)
+        reap_task.add_done_callback(self.__reap_tasks.discard)
+
     async def __get_auth(self) -> tuple[str, str]:
         """Return the (uid, access token) pair."""
         try:
@@ -477,11 +484,7 @@ class ProtonCLI:
                     async with asyncio.timeout(timeout_s):
                         stdout, stderr = await run.process.communicate()
                 except TimeoutError as e:
-                    run.process.kill()
-                    # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
-                    reap_task = asyncio.create_task(run.process.wait())
-                    self.__reap_tasks.add(reap_task)
-                    reap_task.add_done_callback(self.__reap_tasks.discard)
+                    self.__kill_and_reap(run)
                     if attempt >= retries:
                         msg = f"[{run.id}] Command timed out after {timeout_s}s"
                         raise CLITimeoutError(msg) from e
@@ -490,6 +493,11 @@ class ProtonCLI:
                         "[%s] Command timed out after %ss, retrying (%d/%d)", run.id, timeout_s, attempt, retries
                     )
                     continue
+                except asyncio.CancelledError:
+                    # e.g. our sibling in an asyncio.gather() failed: kill our own subprocess too,
+                    # otherwise it lingers and can crash later against files/state cleaned up by the caller.
+                    self.__kill_and_reap(run)
+                    raise
                 return self._process_run(run, stdout, stderr, is_json=is_json)
 
     @classmethod

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -113,6 +113,7 @@ class ProtonCLI:
     DEFAULT_TIMEOUT_S = 10
     METADATA_TIMEOUT_S = 60
     TRANSFER_TIMEOUT_S = 60 * 60
+    TERMINATE_GRACE_S = 5
 
     STALE_AUTH_THRESHOLD = timedelta(hours=24)
     STALE_AUTH_REQUIRED_SUCCESSES = 5
@@ -340,9 +341,20 @@ class ProtonCLI:
         return self._CLIRun(id=uid, process=proc)
 
     def __kill_and_reap(self, run: _CLIRun) -> None:
-        run.process.kill()
-        # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
-        reap_task = asyncio.create_task(run.process.wait())
+        # Give the CLI a chance to exit on its own terms first: a hard SIGKILL can catch it
+        # mid-write to its own on-disk state (e.g. its events lock file), corrupting it and
+        # breaking every subsequent invocation until that file is manually removed.
+        async def _terminate() -> None:
+            run.process.terminate()
+            try:
+                async with asyncio.timeout(self.TERMINATE_GRACE_S):
+                    await run.process.wait()
+            except TimeoutError:
+                run.process.kill()
+                # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
+                await run.process.wait()
+
+        reap_task = asyncio.create_task(_terminate())
         self.__reap_tasks.add(reap_task)
         reap_task.add_done_callback(self.__reap_tasks.discard)
 

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -194,7 +194,7 @@ class ProtonCLI:
         self.__xdg = hass.config.cache_path(DOMAIN, "xdg")
         self.__path = hass.config.cache_path(DOMAIN, "proton-drive")
         self.__integration_version = integration_version
-        self.__reap_tasks: set[asyncio.Task[int]] = set()
+        self.__reap_tasks: set[asyncio.Task[None]] = set()
 
     @classmethod
     async def create(cls, hass: HomeAssistant) -> ProtonCLI:

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -538,7 +538,7 @@ class ProtonCLI:
                         raise
                     attempt += 1
                     delay = min(0.2 * 2 ** (attempt - 1), 2)
-                    LOGGER.warning(
+                    LOGGER.debug(
                         "[%s] CLI cache database locked by a concurrent call, retrying (%d/%d) in %.1fs",
                         run.id,
                         attempt,

--- a/custom_components/proton_drive/cli.py
+++ b/custom_components/proton_drive/cli.py
@@ -85,6 +85,10 @@ class CLIDatabaseLockedError(CLIError):
     """Exception to indicate the CLI's local cache database was locked by a concurrent invocation."""
 
 
+class NameConflictError(CLIError):
+    """Exception to indicate a file/folder with the target name already exists."""
+
+
 def _transform_version(version: AwesomeVersion | None) -> str:
     """
     Map a manifest version into the SDK's `{semver}-{channel}[+{suffix}]` shape.
@@ -217,9 +221,15 @@ class ProtonCLI:
             await self.__download(hass, cached)
 
         try:
-            await self.run("version", is_json=False)
+            cli_version = await self.run("version", is_json=False)
         except CLIError as e:
             raise CLIStartupError(str(e)) from e
+        LOGGER.info(
+            "Proton Drive CLI ready: integration=%s, cli=%s (expected %s)",
+            self.__integration_version,
+            cli_version,
+            CLI_VERSION,
+        )
 
     @classmethod
     async def __get_platform(cls) -> tuple[str, str]:
@@ -340,21 +350,28 @@ class ProtonCLI:
             raise CLIError(msg) from e
         return self._CLIRun(id=uid, process=proc)
 
-    def __kill_and_reap(self, run: _CLIRun) -> None:
+    async def __terminate(self, run: _CLIRun) -> None:
         # Give the CLI a chance to exit on its own terms first: a hard SIGKILL can catch it
         # mid-write to its own on-disk state (e.g. its events lock file), corrupting it and
         # breaking every subsequent invocation until that file is manually removed.
-        async def _terminate() -> None:
-            run.process.terminate()
-            try:
-                async with asyncio.timeout(self.TERMINATE_GRACE_S):
-                    await run.process.wait()
-            except TimeoutError:
-                run.process.kill()
-                # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
+        run.process.terminate()
+        try:
+            async with asyncio.timeout(self.TERMINATE_GRACE_S):
                 await run.process.wait()
+        except TimeoutError:
+            LOGGER.warning(
+                "[%s] Did not exit within %ss of SIGTERM, sending SIGKILL", run.id, self.TERMINATE_GRACE_S
+            )
+            run.process.kill()
+            # awaiting wait() here can block as long as the timeout itself: https://github.com/python/cpython/issues/139373
+            await run.process.wait()
+        else:
+            LOGGER.debug("[%s] Exited cleanly after SIGTERM", run.id)
 
-        reap_task = asyncio.create_task(_terminate())
+    def __kill_and_reap(self, run: _CLIRun) -> None:
+        # Fire-and-forget: used from the timeout-retry loop, where blocking here would delay
+        # the next attempt by up to TERMINATE_GRACE_S for no benefit.
+        reap_task = asyncio.create_task(self.__terminate(run))
         self.__reap_tasks.add(reap_task)
         reap_task.add_done_callback(self.__reap_tasks.discard)
 
@@ -510,9 +527,11 @@ class ProtonCLI:
                     )
                     continue
                 except asyncio.CancelledError:
-                    # e.g. our sibling in an asyncio.gather() failed: kill our own subprocess too,
-                    # otherwise it lingers and can crash later against files/state cleaned up by the caller.
-                    self.__kill_and_reap(run)
+                    # e.g. we were explicitly cancelled because a sibling call failed: wait for our own
+                    # subprocess to actually die before propagating, so the caller can safely clean up
+                    # right after (files/state it deletes won't get pulled out from under a still-running
+                    # process). Unlike the timeout path above, blocking here briefly is fine and desired.
+                    await asyncio.shield(self.__terminate(run))
                     raise
                 try:
                     return self._process_run(run, stdout, stderr, is_json=is_json)
@@ -546,6 +565,9 @@ class ProtonCLI:
             if "SQLITE_BUSY" in stdout_text or "SQLITE_BUSY" in stderr_text:
                 msg = f"[{run.id}] CLI cache database is locked"
                 raise CLIDatabaseLockedError(msg)
+            if "Name conflict on" in stdout_text and "already exists" in stdout_text:
+                msg = f"[{run.id}] Name conflict: {stdout_text}"
+                raise NameConflictError(msg)
             msg = stderr_text
             if "Node not found" in msg:
                 raise NodeNotFoundError(msg)


### PR DESCRIPTION
Submitting this PR to address and solve a few errors I have been having that make this integration unfortunately unusable for me. 

After forking and making the below changes, my backups are now successful and reliable. Requesting these changes be merged with the main branch.

- Updated upload timeout from 10 min to 60 minutes with retries.
- Introduced retries when proton CLI returns `SQLITE_BUSY` instead of failing as DB locks occur frequently with proton CLI
- Introduced softer termination logic to address potential state corruption when backups were cancelled uncleanly
- Introduced move-to-trash for orphaned metadata that would break next backups - this may address a problem that no longer exists once the upload timeouts were fixed but kept it in anyway as additional exception handling
- Removed `SQLITE_BUSY` from being piped to ERROR (and instead, handled to DEBUG) as these responses are expected and not a problem. They are however piped to ERROR when retries completely fail
- Added some more debug logging during troubleshooting

Tested with 4x 1.5GB backups to Proton Drive successfully

Apologies if I have made any contribution errors here